### PR TITLE
Fix Torrent.files when file list is not available

### DIFF
--- a/tpb/tpb.py
+++ b/tpb/tpb.py
@@ -357,9 +357,11 @@ class Torrent(object):
             root = html.fromstring(request.text)
             rows = root.findall('.//tr')
             for row in rows:
-                name, size = [unicode(v.text_content())
-                              for v in row.findall('.//td')]
-                self._files[name] = size.replace('\xa0', ' ')
+                td = row.findall('.//td')
+                if len(td) == 2:
+                    name, size = [unicode(v.text_content())
+                                  for v in td]
+                    self._files[name] = size.replace('\xa0', ' ')
         return self._files
 
     @property


### PR DESCRIPTION
thepiratebay is back!
But some torrents are still unavailable (e.g. https://thepiratebay.se/torrent/7384920 => https://thepiratebay.se/ajax_details_filelist.php?id=7384920) which produces the error that has been fixed in this PR.