### PR TITLE
bypass tpb api block (fix #79)

### DIFF
--- a/tpb/tpb.py
+++ b/tpb/tpb.py
@@ -56,7 +56,7 @@ class List(object):
         Request URL and parse response. Yield a ``Torrent`` for every torrent
         on page.
         """
-        request = get(str(self.url))
+        request = get(str(self.url), headers={'User-Agent' : "Magic Browser","origin_req_host" : "thepiratebay.se"})
         root = html.fromstring(request.text)
         items = [self._build_torrent(row) for row in
                  self._get_torrent_rows(root)]
@@ -342,7 +342,7 @@ class Torrent(object):
     @property
     def info(self):
         if self._info is None:
-            request = get(str(self.url))
+	    request = get(str(self.url), headers={'User-Agent' : "Magic Browser","origin_req_host" : "thepiratebay.se"})
             root = html.fromstring(request.text)
             info = root.cssselect('#details > .nfo > pre')[0].text_content()
             self._info = info
@@ -353,7 +353,7 @@ class Torrent(object):
         if not self._files:
             path = '/ajax_details_filelist.php?id={id}'.format(id=self.id)
             url = self.url.path(path)
-            request = get(str(url))
+	    request = get(str(url), headers={'User-Agent' : "Magic Browser","origin_req_host" : "thepiratebay.se"})
             root = html.fromstring(request.text)
             rows = root.findall('.//tr')
             for row in rows:


### PR DESCRIPTION
see this to understand the problem : http://stackoverflow.com/questions/3336549/pythons-urllib2-why-do-i-get-error-403-when-i-urlopen-a-wikipedia-page
this commit fix it