### PR TITLE
Don't mix tabs and spaces

### DIFF
--- a/tpb/tpb.py
+++ b/tpb/tpb.py
@@ -342,7 +342,7 @@ class Torrent(object):
     @property
     def info(self):
         if self._info is None:
-	    request = get(str(self.url), headers={'User-Agent' : "Magic Browser","origin_req_host" : "thepiratebay.se"})
+            request = get(str(self.url), headers={'User-Agent' : "Magic Browser","origin_req_host" : "thepiratebay.se"})
             root = html.fromstring(request.text)
             info = root.cssselect('#details > .nfo > pre')[0].text_content()
             self._info = info
@@ -353,7 +353,7 @@ class Torrent(object):
         if not self._files:
             path = '/ajax_details_filelist.php?id={id}'.format(id=self.id)
             url = self.url.path(path)
-	    request = get(str(url), headers={'User-Agent' : "Magic Browser","origin_req_host" : "thepiratebay.se"})
+            request = get(str(url), headers={'User-Agent' : "Magic Browser","origin_req_host" : "thepiratebay.se"})
             root = html.fromstring(request.text)
             rows = root.findall('.//tr')
             for row in rows:


### PR DESCRIPTION
#80 introduced a "TabError: inconsistent use of tabs and spaces in indentation" ([Travis report](https://travis-ci.org/karan/TPB/jobs/51122883)). Replacing the tabs with spaces fixes this issue.