### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Unofficial Python API for [ThePirateBay](http://thepiratebay.org/).
 
 | Build Status | Test Coverage | Version | Downloads (30 days) |
 | ------------ | ------------- | ------- | ------------------- |
-| [![Build Status](https://travis-ci.org/karan/TPB.png?branch=master)](https://travis-ci.org/karan/TPB) | [![Coverage Status](https://coveralls.io/repos/karan/TPB/badge.png)](https://coveralls.io/r/karan/TPB) | [![Latest Version](https://pypip.in/v/ThePirateBay/badge.png)](https://pypi.python.org/pypi/ThePirateBay/) | [![Downloads](https://pypip.in/d/ThePirateBay/badge.png)](https://pypi.python.org/pypi/ThePirateBay/) |
+| [![Build Status](https://travis-ci.org/karan/TPB.png?branch=master)](https://travis-ci.org/karan/TPB) | [![Coverage Status](https://coveralls.io/repos/karan/TPB/badge.png)](https://coveralls.io/r/karan/TPB) | [![Latest Version](https://img.shields.io/pypi/v/ThePirateBay.svg)](https://pypi.python.org/pypi/ThePirateBay/) | [![Downloads](https://img.shields.io/pypi/dm/ThePirateBay.svg)](https://pypi.python.org/pypi/ThePirateBay/) |
 
 Installation
 =============


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20thepiratebay))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `thepiratebay`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.