### PR TITLE
fixed URL lib calls, fixed HTTP error, working on python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ purl==0.8
 lxml==3.2.3
 python-dateutil==2.2
 cssselect==0.9.1
-requests==2.3.0
+requests==2.20.0

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,17 +6,16 @@ import time
 import unittest
 
 from lxml import html
+from requests import get
 
 from tpb.tpb import TPB, Search, Recent, Top, List, Paginated
 from tpb.constants import ConstantType, Constants, ORDERS, CATEGORIES
-from tpb.utils import URL
+from tpb.utils import URL, headers
 
 if sys.version_info >= (3, 0):
-    from urllib.request import urlopen
     from tests.cases import RemoteTestCase
     unicode = str
 else:
-    from urllib2 import urlopen
     from cases import RemoteTestCase
 
 
@@ -106,8 +105,12 @@ class ParsingTestCase(RemoteTestCase):
         self.assertTrue(diff > 1)
 
     def test_torrent_rows(self):
-        request = urlopen(str(self.torrents.url))
-        document = html.parse(request)
+        request = get(
+            str(self.torrents.url),
+            headers=headers(),
+            stream=True
+        )
+        document = html.parse(request.raw)
         rows = self.torrents._get_torrent_rows(document.getroot())
         self.assertEqual(len(rows), 30)
 

--- a/tpb/tpb.py
+++ b/tpb/tpb.py
@@ -18,7 +18,7 @@ import re
 import sys
 import time
 
-from .utils import URL
+from .utils import URL, headers
 
 from requests import get
 
@@ -56,7 +56,7 @@ class List(object):
         Request URL and parse response. Yield a ``Torrent`` for every torrent
         on page.
         """
-        request = get(str(self.url), headers={'User-Agent' : "Magic Browser","origin_req_host" : "thepiratebay.se"})
+        request = get(str(self.url), headers=headers())
         root = html.fromstring(request.text)
         items = [self._build_torrent(row) for row in
                  self._get_torrent_rows(root)]
@@ -342,7 +342,7 @@ class Torrent(object):
     @property
     def info(self):
         if self._info is None:
-            request = get(str(self.url), headers={'User-Agent' : "Magic Browser","origin_req_host" : "thepiratebay.se"})
+            request = get(str(self.url), headers=headers())
             root = html.fromstring(request.text)
             info = root.cssselect('#details > .nfo > pre')[0].text_content()
             self._info = info
@@ -353,7 +353,7 @@ class Torrent(object):
         if not self._files:
             path = '/ajax_details_filelist.php?id={id}'.format(id=self.id)
             url = self.url.path(path)
-            request = get(str(url), headers={'User-Agent' : "Magic Browser","origin_req_host" : "thepiratebay.se"})
+            request = get(str(url), headers=headers())
             root = html.fromstring(request.text)
             rows = root.findall('.//tr')
             for row in rows:

--- a/tpb/utils.py
+++ b/tpb/utils.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+import random
 
 from purl import URL as PURL
 
@@ -61,3 +62,32 @@ class Segments(object):
             fget=lambda x: cls._get_segment(x, segment),
             fset=lambda x, v: cls._set_segment(x, segment, v),
         )
+
+
+def headers():
+    """
+    The Pirate Bay blocks requests (403 Forbidden)
+    basing on User-Agent header, so it's probably better to rotate them.
+    User-Agents taken from:
+    https://techblog.willshouse.com/2012/01/03/most-common-user-agents/
+    """
+    return {
+        "User-Agent": random.choice(USER_AGENTS),
+        "origin_req_host": "thepiratebay.se",
+    }
+
+
+USER_AGENTS = (
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+    'AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/60.0.3112.113 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+    'AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/60.0.3112.101 Safari/537.36',
+    'Mozilla/5.0 (Windows NT 6.1; Win64; x64) '
+    'AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/60.0.3112.113 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) '
+    'AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/60.0.3112.113 Safari/537.36',
+)


### PR DESCRIPTION
This update allows the API to function in the latest version of python 3.8 / 3.9. 

Was getting an HTTP error beforehand using urllib and replaced it with requests.