### PR TITLE
Fixed issue relating to row parsing on other mirrors than piratebay.org

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Internet :: WWW/HTTP :: Browsers',
         'Topic :: Internet :: WWW/HTTP :: Indexing/Search',
         'Topic :: Utilities',

--- a/tpb/tpb.py
+++ b/tpb/tpb.py
@@ -75,7 +75,9 @@ class List(object):
         if table is None:  # no table means no results:
             return []
         else:
-            return table.findall('.//tr')[1:]  # get all rows but header
+            query: list = table.findall(".//tr") #Fixes the last td element only having column problem.
+            range: int = len(query)
+            return query[1:range-1] # get all rows but header
 
     def _build_torrent(self, row):
         """
@@ -83,9 +85,10 @@ class List(object):
         """
         # Scrape, strip and build!!!
         cols = row.findall('.//td')  # split the row into it's columns
-
+        
         # this column contains the categories
-        [category, sub_category] = [c.text for c in cols[0].findall('.//a')]
+        category: str = cols[0].findall(".//a")[0].text
+        sub_category: str = cols[0].findall(".//a")[1].text
 
         # this column with all important info
         links = cols[1].findall('.//a')  # get 4 a tags from this columns


### PR DESCRIPTION
The previous version of this didn't allow functionality on anything other than piratebay.org. I made a fix so that it can work on all functioning mirrors of ThePirateBay. This was a fix of what rows it is allowed to parse, as the previous one included the last row to be parsed which had a column count of 1 instead of the typical 4.